### PR TITLE
✨ admin page: dashboard

### DIFF
--- a/frontend/__tests__/piechart.test.jsx
+++ b/frontend/__tests__/piechart.test.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import PieChart from "@/components/PieChart.jsx";
+import "@testing-library/jest-dom";
+
+test("renders the correct number of segments", () => {
+  const fractions = [0.2, 0.3, 0.5];
+  const circleWidth = 200;
+  const radius = 50;
+  const { container } = render(
+    <PieChart fractions={fractions} circleWidth={circleWidth} radius={radius} />
+  );
+  const segments = container.querySelectorAll("circle");
+  expect(segments.length).toBe(fractions.length);
+});
+
+test("renders each segment with the correct stroke color", () => {
+  const fractions = [0.2, 0.3, 0.5];
+  const circleWidth = 200;
+  const radius = 50;
+  const { container } = render(
+    <PieChart fractions={fractions} circleWidth={circleWidth} radius={radius} />
+  );
+  const segments = container.querySelectorAll("circle");
+  expect(segments[0]).toHaveStyle("stroke: var(--color-bad-1)");
+  expect(segments[1]).toHaveStyle("stroke: var(--color-meh-1)");
+  expect(segments[2]).toHaveStyle("stroke: var(--color-done-1)");
+});
+
+test("renders each segment with the correct rotation", () => {
+  const fractions = [0.2, 0.3, 0.5];
+  const circleWidth = 200;
+  const radius = 50;
+  const { container } = render(
+    <PieChart fractions={fractions} circleWidth={circleWidth} radius={radius} />
+  );
+  const segments = container.querySelectorAll("circle");
+  expect(segments[0]).toHaveAttribute("transform", "rotate(-90 100 100)");
+  expect(segments[1]).toHaveAttribute("transform", "rotate(-18 100 100)");
+  expect(segments[2]).toHaveAttribute("transform", "rotate(90 100 100)");
+});

--- a/frontend/src/components/PieChart.jsx
+++ b/frontend/src/components/PieChart.jsx
@@ -1,0 +1,53 @@
+import { COLOR_DONE_1, COLOR_BAD_1, COLOR_MEH_1 } from "@/utils/colors";
+import { clamp } from "@/utils/helpers";
+
+/**
+ * Piechart element where you can make a wheel with multiple segments
+ * @param fractions A list of (maximum) 3 floats between 0 and 1 that represent the fractions of the wheel
+ * @param circleWidth Width of the wheel
+ * @param radius The radius of the wheel
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export default function PieChart({ fractions, circleWidth, radius }) {
+  const percentages = fractions.map((fraction) =>
+    clamp(0, fraction * 100, 100)
+  );
+  const dashArray = radius * Math.PI * 2;
+
+  let colors = [COLOR_BAD_1, COLOR_MEH_1, COLOR_DONE_1];
+
+  let cumulativeFractions = 0;
+  const rotations = fractions.map((fraction) => {
+    cumulativeFractions += fraction;
+    return -90 + 360 * (cumulativeFractions - fraction);
+  });
+
+  return (
+    <svg
+      width={circleWidth}
+      height={circleWidth}
+      viewBox={`0 0 ${circleWidth} ${circleWidth}`}
+      className={""}
+    >
+      {percentages.map((percentage, index) => (
+        <circle
+          cx={circleWidth / 2}
+          cy={circleWidth / 2}
+          strokeWidth={"15px"}
+          r={radius || 0}
+          className={"fill-none"}
+          key={index}
+          style={{
+            strokeDasharray: dashArray,
+            strokeDashoffset: dashArray - (dashArray * percentage) / 100,
+            stroke: colors[index],
+          }}
+          transform={`rotate(${rotations[index]} ${circleWidth / 2} ${
+            circleWidth / 2
+          })`}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/components/PieChart.jsx
+++ b/frontend/src/components/PieChart.jsx
@@ -34,7 +34,7 @@ export default function PieChart({ fractions, circleWidth, radius }) {
         <circle
           cx={circleWidth / 2}
           cy={circleWidth / 2}
-          strokeWidth={"15px"}
+          strokeWidth={"20px"}
           r={radius || 0}
           className={"fill-none"}
           key={index}

--- a/frontend/src/pages/admin/planning.jsx
+++ b/frontend/src/pages/admin/planning.jsx
@@ -10,6 +10,7 @@ import {
   faSort,
   faComment,
   faBicycle,
+  faChartPie,
 } from "@fortawesome/free-solid-svg-icons";
 import CustomWeekPicker from "@/components/input-fields/CustomWeekPicker";
 import { useEffect, useRef, useState } from "react";
@@ -158,7 +159,7 @@ export default function AdminDashboardPage() {
         <Link
           key={entry.url}
           href={`/admin/planningen/${urlToPK(entry.url)}`}
-          className={"bg-primary-2 border-2 rounded-lg p-1"}
+          className={"bg-primary-2 border-2 border-light-h-2 rounded-lg p-1"}
         >
           Details
         </Link>,
@@ -215,30 +216,41 @@ export default function AdminDashboardPage() {
             setStartDate(newStartDate);
             setEndDate(newEndDate);
           }}
+          className="!light-bg-1"
         />
       </div>
 
       <PrimaryCard>
-        <div id={"statistics"} className={"flex flex-row grid grid-cols-3"}>
+        <div id={"statistics"} className={"flex flex-row grid grid-cols-2"}>
+          <div className="flex flex-col">
+            <SecondaryCard
+              title={"Aantal Rondes"}
+              className={"m-2 justify-center items-center flex-1"}
+              icon={faBicycle}
+            >
+              {entries.length === 1 ? (
+                <p className={"font-bold"}>{entries.length} ronde</p>
+              ) : (
+                <p className={"font-bold"}>{entries.length} rondes</p>
+              )}
+            </SecondaryCard>
+            <SecondaryCard
+              icon={faComment}
+              title={"Aantal opmerkingen"}
+              className={"m-2 justify-center items-center flex-1"}
+            >
+              {amountOfComments === 1 ? (
+                <p className={"font-bold"}>{amountOfComments} opmerking</p>
+              ) : (
+                <p className={"font-bold"}>{amountOfComments} opmerkingen</p>
+              )}
+            </SecondaryCard>
+          </div>
           <SecondaryCard
-            title={"Aantal Rondes"}
-            className={"m-2 justify-center items-center"}
-            icon={faBicycle}
-          >
-            {entries.length === 1 ? (
-              <p className={"font-bold"}>{entries.length} Ronde</p>
-            ) : (
-              <p className={"font-bold"}>{entries.length} Rondes</p>
-            )}
-          </SecondaryCard>
-          <SecondaryCard
-            icon={faComment}
-            title={"Aantal opmerkingen"}
+            title={"Overzicht"}
+            icon={faChartPie}
             className={"m-2"}
           >
-            <p className={"font-bold"}>{amountOfComments} opmerkingen</p>
-          </SecondaryCard>
-          <SecondaryCard title={"Overzicht"} className={"m-2"}>
             {entries.length > 0 && (
               <div className={"flex flex-col lg:flex-row items-center"}>
                 <PieChart
@@ -248,20 +260,16 @@ export default function AdminDashboardPage() {
                     amountOfStarted / entries.length,
                     amountOfCompleted / entries.length,
                   ]}
-                  circleWidth={150}
-                  radius={50}
+                  circleWidth={200}
+                  radius={70}
                 />
-                <div>
-                  <p className={"text-bad-1 font-bold"}>
+                <div className="font-bold">
+                  <p className={"text-bad-1"}>
                     {entries.length - amountOfCompleted - amountOfStarted}
                     {" Nog niet begonnen"}
                   </p>
-                  <p className={"text-meh-1 font-bold"}>
-                    {amountOfStarted} Onderweg
-                  </p>
-                  <p className={"text-done-1 font-bold"}>
-                    {amountOfCompleted} Compleet
-                  </p>
+                  <p className={"text-meh-1"}>{amountOfStarted} Onderweg</p>
+                  <p className={"text-done-1"}>{amountOfCompleted} Compleet</p>
                 </div>
               </div>
             )}
@@ -297,7 +305,7 @@ export default function AdminDashboardPage() {
                     <CustomInputField
                       icon={faMagnifyingGlass}
                       reference={searchString}
-                      classNameDiv={"h-6"}
+                      classNameDiv={"h-8"}
                       actionCallback={() =>
                         performSearch(entries, sortString, filterString)
                       }


### PR DESCRIPTION
Closes #131 

I've added following things to the admin dashboard page:

- A piechart component which represents the number of completed schedules (with tests)
- Fetch the number of comments per schedule (and its visits) 
- A filter dropdown which filters on the completeness of the schedules ('nog niet begonnen', 'onderweg' and 'compleet')
- A sort dropdown which can sort on a few columns ('datum', 'ronde' and 'student')
- The inputfield can search based on the round names and student names 

![admin_dashboard](https://user-images.githubusercontent.com/125481977/236778069-d01fe93d-8daf-4934-80ac-c917c578f323.PNG)
