### PR TITLE
:recycle: creating tours endpoint consistency fix

### DIFF
--- a/backend/drtrottoir/urls.py
+++ b/backend/drtrottoir/urls.py
@@ -20,8 +20,8 @@ from .views import (
     RegisterView,
     PhotoViewSet,
     MeView,
-    VisitCommentView,
-    ScheduleCommentView
+    VisitCommentViewSet,
+    ScheduleCommentViewSet
 )
 
 router = routers.DefaultRouter()
@@ -35,8 +35,8 @@ router.register(r'schedule', ScheduleViewSet)
 router.register(r'photo', PhotoViewSet)
 router.register(r'waste', WasteViewSet)
 router.register(r'waste', WasteViewSet)
-router.register(r'visit_comment', VisitCommentView)
-router.register(r'schedule_comment', ScheduleCommentView)
+router.register(r'visit_comment', VisitCommentViewSet)
+router.register(r'schedule_comment', ScheduleCommentViewSet)
 
 urlpatterns = [
     path('user/auth/', TokenObtainPairView.as_view(), name='token_obtain_pair'),

--- a/backend/drtrottoir/views/__init__.py
+++ b/backend/drtrottoir/views/__init__.py
@@ -9,7 +9,7 @@ from .schedule_viewset import ScheduleViewSet
 from .photo_viewset import PhotoViewSet
 from .register_view import RegisterView
 from .me_view import MeView
-from .comment_viewset import VisitCommentView, ScheduleCommentView
+from .comment_viewset import VisitCommentViewSet, ScheduleCommentViewSet
 
 __all__ = [
     BuildingViewSet,
@@ -24,6 +24,6 @@ __all__ = [
     BuildingInTourViewSet,
     RegisterView,
     MeView,
-    VisitCommentView,
-    ScheduleCommentView
+    VisitCommentViewSet,
+    ScheduleCommentViewSet
 ]

--- a/backend/drtrottoir/views/comment_viewset.py
+++ b/backend/drtrottoir/views/comment_viewset.py
@@ -8,7 +8,7 @@ from pytz import timezone
 from datetime import datetime
 
 
-class CommentView(viewsets.ModelViewSet):
+class CommentViewSet(viewsets.ModelViewSet):
 
     def create(self, request):
         if any(x in request.data for x in ('user', 'created_at', 'updated_at')):
@@ -48,7 +48,7 @@ class CommentView(viewsets.ModelViewSet):
         abstract = True
 
 
-class ScheduleCommentView(CommentView):
+class ScheduleCommentViewSet(CommentViewSet):
     """
     retrieve:
     API endpoint that allows a comment on a schedule to be retrieved. Authentication required.
@@ -74,7 +74,7 @@ class ScheduleCommentView(CommentView):
     serializer_class = ScheduleCommentSerializer
 
 
-class VisitCommentView(CommentView):
+class VisitCommentViewSet(CommentViewSet):
     """
     retrieve:
     API endpoint that allows a comment on a visit to be retrieved.

--- a/backend/drtrottoir/views/schedule_viewset.py
+++ b/backend/drtrottoir/views/schedule_viewset.py
@@ -15,7 +15,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
     queryset = Schedule.objects.all()
     serializer_class = ScheduleSerializer
     permission_classes = [IsAuthenticated & SuperPermissionOrReadOnly]
-   
+
     # Get visits for schedule
     @action(detail=True, methods=['get'])
     def visits(self, request, pk=None):

--- a/backend/drtrottoir/views/schedule_viewset.py
+++ b/backend/drtrottoir/views/schedule_viewset.py
@@ -15,7 +15,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
     queryset = Schedule.objects.all()
     serializer_class = ScheduleSerializer
     permission_classes = [IsAuthenticated & SuperPermissionOrReadOnly]
-
+   
     # Get visits for schedule
     @action(detail=True, methods=['get'])
     def visits(self, request, pk=None):

--- a/backend/drtrottoir/views/tour_viewset.py
+++ b/backend/drtrottoir/views/tour_viewset.py
@@ -3,7 +3,7 @@ from rest_framework import status, viewsets
 from drtrottoir.models import Tour, Region, BuildingInTour
 from drtrottoir.permissions import SuperPermissionOrReadOnly
 
-from drtrottoir.serializers import TourSerializer, RegionSerializer, BuildingInTourPartialSerializer
+from drtrottoir.serializers import TourSerializer, BuildingInTourPartialSerializer
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response

--- a/backend/drtrottoir/views/tour_viewset.py
+++ b/backend/drtrottoir/views/tour_viewset.py
@@ -34,40 +34,34 @@ class TourViewSet(viewsets.ModelViewSet):
     queryset = Tour.objects.all()
     permission_classes = [IsAuthenticated & SuperPermissionOrReadOnly]
 
-    def create(self, request, *args, **kwargs):
-        data = request.data
-        if 'id' in data:  # Create a new version of an existing tour
-            if Tour.objects.filter(pk=data["id"]).exists():
-                buildings_tour = BuildingInTour.objects.filter(tour=data["id"])
-                tour = Tour.objects.get(pk=data["id"])
-                name = tour.name
-                region = tour.region
-                new_tour = Tour.objects.create(region=region, name=name)
-                for build_tour in buildings_tour:  # We will also copy all BuildingInTour objects
-                    BuildingInTour.objects.create(tour=new_tour, building=build_tour.building,
-                                                  order_index=build_tour.order_index)
-                serializer = self.get_serializer_class()
-                ser = serializer(instance=new_tour, context={'request': request})
-                return Response({'tour': ser.data})
-            else:
-                return Response("Given tour doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
-        elif "region" in data and "name" in data:  # Region must be the id
-            if Region.objects.filter(pk=data["region"]).exists():
-                region = Region.objects.get(pk=data["region"])
-                reg_ser = RegionSerializer(instance=region, context={'request': request})
-                name = data["name"]
-                serializer = self.get_serializer_class()
-                ser = serializer(data={"region": reg_ser.data["url"], "name": name}, context={'request': request})
-                if ser.is_valid(raise_exception=True):
-                    ser.save()
-                    return Response({'tour': ser.data})
-                else:
+    @action(detail=True, methods=['post'])
+    def duplicate(self, request, pk=None):
+        if not Tour.objects.filter(pk=pk).exists():
+            return Response("Given tour doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
+        old_tour = Tour.objects.get(pk=pk)
+        d = request.data
 
-                    return Response("Given values are not valid", status=status.HTTP_400_BAD_REQUEST)
-            else:
-                return Response("Given region doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
-        else:
-            return Response("Given values are not valid", status=status.HTTP_400_BAD_REQUEST)
+        # create new tour
+        name = d["name"] if "name" in d else old_tour.name
+        region = old_tour.region
+        if "region" in d:
+            r = str(d["region"])
+            regionpk = list(filter(lambda x: x, r.split("/")))[-1]  # extract pk
+            if not (
+                "region" in r and
+                regionpk.isdigit() and
+                Region.objects.filter(pk=int(regionpk)).exists()
+            ):
+                return Response("Given region is not valid (requires valid url)", status=status.HTTP_400_BAD_REQUEST)
+            region = Region.objects.get(pk=int(regionpk))
+        new_tour = Tour.objects.create(region=region, name=name)
+
+        # copy all BuildinInTour objects
+        buildings_in_tour = BuildingInTour.objects.filter(tour=pk)
+        for b in buildings_in_tour:
+            BuildingInTour.objects.create(tour=new_tour, building=b.building, order_index=b.order_index)
+
+        return Response(TourSerializer(new_tour, context={'request': request}).data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['get'])
     def buildings(self, request, pk=None):

--- a/backend/drtrottoir/views/user_viewset.py
+++ b/backend/drtrottoir/views/user_viewset.py
@@ -1,6 +1,7 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated
-
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from drtrottoir.models import CustomUser
 from drtrottoir.permissions.user_permissions import UserViewSetPermission
 from drtrottoir.serializers import UserSerializer
@@ -29,3 +30,13 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = CustomUser.objects.all().order_by('id')
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated & UserViewSetPermission]
+
+    # Marks user as removed
+    @action(detail=True, methods=['post'])
+    def remove(self, request, pk=None):
+        # Check if user id is valid
+        if pk is None or not CustomUser.objects.filter(pk=pk).exists():
+            return Response("Given building doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
+        user = CustomUser.objects.get(pk=pk)
+        user.is_active = False
+        user.save()


### PR DESCRIPTION
This PR fixes the consistency of the POST tour endpoint (using url instead of id).
Creating new versions of a tour is now done using a separate endpoint `/tour/{id}/duplicate`.
Separate tests are also included in PR