### PR TITLE
:bug: User Activation Endpoints

### DIFF
--- a/backend/drtrottoir/admin.py
+++ b/backend/drtrottoir/admin.py
@@ -29,8 +29,16 @@ class UserAdmin(BaseUserAdmin):
     list_display = ('email', 'role')
     list_filter = ('role',)
     fieldsets = (
-        (None, {'fields': ('email', 'password')}),
+        (None, {'fields': (
+            'email',
+            'password',
+            'first_name',
+            'last_name',
+            'phone',
+            'is_active'
+        )}),
         ('Permissions', {'fields': ('role',)}),
+        ('Region', {'fields': ('region',)})
     )
     # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin
     # overrides get_fieldsets to use this attribute when creating a user.

--- a/backend/drtrottoir/permissions/user_permissions.py
+++ b/backend/drtrottoir/permissions/user_permissions.py
@@ -76,12 +76,12 @@ class PhotoPermission(BasePermission):
 
 class UserViewSetPermission(BasePermission):
     """
-    Including this permission allows only superadmins to GET index page.
-    Only Users that own the record and superadmins can view and edit that record.
+    Including this permission allows only super permissions to GET index page.
+    Only Users that own the record and super permissions can view and edit that record.
     """
 
     def has_permission(self, request, view):
-        return (request.user.role <= Roles.SUPERADMIN and request.method in SAFE_METHODS) or 'pk' in view.kwargs
+        return (request.user.is_super and request.method in SAFE_METHODS) or 'pk' in view.kwargs
 
     def has_object_permission(self, request, view, obj):
-        return request.user.role <= Roles.SUPERADMIN or (obj == request.user and request.method in SAFE_METHODS)
+        return request.user.is_super or (obj == request.user and request.method in SAFE_METHODS)

--- a/backend/drtrottoir/serializers/register_serializer.py
+++ b/backend/drtrottoir/serializers/register_serializer.py
@@ -34,9 +34,11 @@ class RegisterSerializer(serializers.HyperlinkedModelSerializer):
             first_name=validated_data['first_name'],
             last_name=validated_data['last_name'],
             is_active=False,
-            phone=validated_data['phone'],
             role=Roles.STUDENT
         )
+
+        if 'phone' in validated_data:
+            user.phone = validated_data['phone']
 
         user.set_password(validated_data['password'])
         user.save()

--- a/backend/drtrottoir/serializers/register_serializer.py
+++ b/backend/drtrottoir/serializers/register_serializer.py
@@ -17,7 +17,7 @@ class RegisterSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = CustomUser
-        fields = ('password', 'password2', 'email', 'first_name', 'last_name')
+        fields = ('password', 'password2', 'email', 'first_name', 'last_name', 'phone')
         extra_kwargs = {
             'first_name': {'required': True},
             'last_name': {'required': True},
@@ -34,6 +34,7 @@ class RegisterSerializer(serializers.HyperlinkedModelSerializer):
             first_name=validated_data['first_name'],
             last_name=validated_data['last_name'],
             is_active=False,
+            phone=validated_data['phone'],
             role=Roles.STUDENT
         )
 

--- a/backend/drtrottoir/serializers/user_serializer.py
+++ b/backend/drtrottoir/serializers/user_serializer.py
@@ -26,6 +26,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'region',
             'region_name',
             'role',
-            'buildings'
+            'buildings',
+            'phone',
+            'is_active'
         ]
-        read_only_field = ['is_active']

--- a/backend/drtrottoir/serializers/user_serializer.py
+++ b/backend/drtrottoir/serializers/user_serializer.py
@@ -14,6 +14,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         source='region.region_name',
         read_only=True
     )
+    active = serializers.CharField(source='is_active', read_only=True)
 
     class Meta:
         model = User
@@ -28,5 +29,5 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'role',
             'buildings',
             'phone',
-            'is_active'
+            'active'
         ]

--- a/backend/drtrottoir/tests/views/test_register.py
+++ b/backend/drtrottoir/tests/views/test_register.py
@@ -3,19 +3,34 @@ from rest_framework.test import APITestCase
 from django.urls import reverse
 
 from drtrottoir.models import CustomUser
+from drtrottoir.tests.factories import (SuperStudentUserFactory)
 
 
 class TestRegisterView(APITestCase):
     """ Test module for GET single Region API """
 
-    def test_post(self):
-        data = {
+    def setUp(self):
+        self.data = {
             "email": "test123@test123.com",
             "password": "testtest123",
             "password2": "testtest123",
             "first_name": "first",
             "last_name": "last"
         }
-        response = self.client.post(reverse("auth_register"), data=data)
+
+    def test_post(self):
+        response = self.client.post(reverse("auth_register"), data=self.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(CustomUser.objects.filter(email=data['email']).exists())
+        self.assertTrue(CustomUser.objects.filter(email=self.data['email']).exists())
+
+    def test_activate(self):
+        response = self.client.post(reverse("auth_register"), data=self.data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user = CustomUser.objects.get(email=self.data['email'])
+        self.assertFalse(user.is_active)
+
+        self.client.force_authenticate(user=SuperStudentUserFactory())
+        response = self.client.post(f'/api/user/{user.pk}/activate/', follow=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user = CustomUser.objects.get(email=self.data['email'])
+        self.assertTrue(user.is_active)

--- a/backend/drtrottoir/tests/views/test_register.py
+++ b/backend/drtrottoir/tests/views/test_register.py
@@ -15,13 +15,18 @@ class TestRegisterView(APITestCase):
             "password": "testtest123",
             "password2": "testtest123",
             "first_name": "first",
-            "last_name": "last"
+            "last_name": "last",
+            "phone": "0412345678"
         }
 
     def test_post(self):
         response = self.client.post(reverse("auth_register"), data=self.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(CustomUser.objects.filter(email=self.data['email']).exists())
+        user = CustomUser.objects.get(email=self.data['email'])
+        self.assertEqual(user.first_name, self.data['first_name'])
+        self.assertEqual(user.last_name, self.data['last_name'])
+        self.assertEqual(user.phone, self.data['phone'])
 
     def test_activate(self):
         response = self.client.post(reverse("auth_register"), data=self.data)

--- a/backend/drtrottoir/tests/views/test_user.py
+++ b/backend/drtrottoir/tests/views/test_user.py
@@ -95,3 +95,10 @@ class TestUserView(APITestCase):
         self.client.force_authenticate(user=self.users[Roles.OWNER])
         response = self.client.delete(f'/api/user/{self.users[Roles.STUDENT].pk}/', follow=True)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_remove(self):
+        self.client.force_authenticate(user=self.users[Roles.STUDENT])
+        response = self.client.post(f'/api/user/{self.users[Roles.STUDENT].pk}/remove/', follow=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get(f'/api/user/{self.users[Roles.STUDENT].pk}', follow=True)
+        self.assertEqual(response.data['active'], 'False')

--- a/backend/drtrottoir/views/user_viewset.py
+++ b/backend/drtrottoir/views/user_viewset.py
@@ -3,7 +3,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from drtrottoir.models import CustomUser
-from drtrottoir.permissions.user_permissions import UserViewSetPermission
+from drtrottoir.permissions.user_permissions import UserViewSetPermission, SuperPermission
 from drtrottoir.serializers import UserSerializer
 
 
@@ -40,3 +40,27 @@ class UserViewSet(viewsets.ModelViewSet):
         user = CustomUser.objects.get(pk=pk)
         user.is_active = False
         user.save()
+        return Response(status=status.HTTP_200_OK)
+
+    # Marks user as active
+    @action(detail=True, methods=['post'], permission_classes=[SuperPermission])
+    def activate(self, request, pk=None):
+        # Check if user id is valid
+        if pk is None or not CustomUser.objects.filter(pk=pk).exists():
+            return Response("Given user doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
+        user = CustomUser.objects.get(pk=pk)
+        user.is_active = True
+        user.save()
+        return Response(status=status.HTTP_200_OK)
+
+    # Returns inactive users
+    @action(detail=False, methods=['get'], permission_classes=[SuperPermission])
+    def inactive(self, request):
+        users = CustomUser.objects.filter(is_active=False)
+        return Response(UserSerializer(list(users), many=True, context={'request': request}).data)
+
+    # Returns active users
+    @action(detail=False, methods=['get'], permission_classes=[SuperPermission])
+    def active(self, request):
+        users = CustomUser.objects.filter(is_active=True)
+        return Response(UserSerializer(list(users), many=True, context={'request': request}).data)

--- a/backend/drtrottoir/views/user_viewset.py
+++ b/backend/drtrottoir/views/user_viewset.py
@@ -36,7 +36,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def remove(self, request, pk=None):
         # Check if user id is valid
         if pk is None or not CustomUser.objects.filter(pk=pk).exists():
-            return Response("Given building doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
+            return Response("Given user doesn't exist.", status=status.HTTP_400_BAD_REQUEST)
         user = CustomUser.objects.get(pk=pk)
         user.is_active = False
         user.save()


### PR DESCRIPTION
Adds 4 new endpoints (necessary to ensure the right permissions):
POST `/user/{id}/remove/` Set user inactive (super permission or user permission required)
POST `/user/{id}/activate/` Set user active (super permission required)
GET `/user/active/` Lists all active users (super permission required)
GET `/user/inactive/` Lists all active users (super permission required)

Phone and active fields are added in user serializer, active field can only be updated using the endpoints described above.