### PR TITLE
🚚 Change navbar + login behaviour

### DIFF
--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -23,7 +23,7 @@ export default function Navbar() {
   return (
     <div className={"flex flex-col flex-shrink-0 sm:w-64 h-full bg-dark-bg-1"}>
       <div className={"flex justify-center p-1 mb-2 mt-8"}>
-        <Link href={"/home"}>
+        <Link href={"/admin/home"}>
           <Image src={Logo} className="w-36 object-fill" alt="logo" />
         </Link>
       </div>

--- a/frontend/src/pages/index.jsx
+++ b/frontend/src/pages/index.jsx
@@ -43,7 +43,7 @@ export default function Login() {
 
     const user = (await getSession()).user;
     if (user.role <= ROLES.SUPERSTUDENT) {
-      await router.push("/admin/dashboard");
+      await router.push("/beheer/planning");
     } else if (user.role === ROLES.STUDENT) {
       await router.push("/student/planning");
     } else if (user.role === ROLES.SYNDICUS) {


### PR DESCRIPTION
closes #325 

Changes
- When logging in, admins are redirected to `/beheer/planningen`
- The DrTrottoir logo now redirects to `/home`, this can be changed if we want to get rid of `/home` now.