### PR TITLE
waste endpoint parameter querying

### DIFF
--- a/backend/drtrottoir/views/waste_viewset.py
+++ b/backend/drtrottoir/views/waste_viewset.py
@@ -1,5 +1,6 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from drtrottoir.models import Waste
 from drtrottoir.permissions import SuperStudentPermissionOrReadOnly
 from drtrottoir.serializers import WasteSerializer
@@ -28,3 +29,53 @@ class WasteViewSet(viewsets.ModelViewSet):
     queryset = Waste.objects.all()
     serializer_class = WasteSerializer
     permission_classes = [IsAuthenticated & SuperStudentPermissionOrReadOnly]
+
+    def list(self, request):
+        q_params = request.query_params
+        q_param_keys = q_params.keys()
+        params = [
+            "date",
+            "start",
+            "end",
+        ]
+
+        # Catch unknown parameters
+        unknown_params = list(filter(lambda x: x not in params, q_param_keys))
+        if unknown_params:
+            return Response(
+                f"Unknown query params: {', '.join(unknown_params)}. Valid params: {params}",
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if "date" in q_param_keys:
+            # Catch wrong usage of date param
+            if len(q_param_keys) > 1:
+                return Response(
+                    "Can't combine 'date' parameter with another parameter",
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            try:
+                q = Waste.objects.filter(date=q_params["date"]).order_by('id')
+                # Return WastePartialSerializer
+                return Response(WasteSerializer(list(q), many=True, context={'request': request}).data)
+
+            except Exception:  # Catch ivalid date
+                return Response(
+                    "Invalid date: date must be of format (YYYY-MM-DD)",
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+        
+        # Start and End params
+        try:
+            # Adds date__gte field when start param is present and date__gte field when end param is present
+            arg = {"date__gte" if k == "start" else "date__lte": q_params[k] for k in q_param_keys}
+            q = Waste.objects.filter(**arg).order_by('date')
+            # Return WastePartialSerializer
+            return Response(WasteSerializer(list(q), many=True, context={'request': request}).data)
+
+        except Exception:  # Catch ivalid dates
+            return Response(
+                "Invalid date: date must be of format (YYYY-MM-DD)",
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/backend/drtrottoir/views/waste_viewset.py
+++ b/backend/drtrottoir/views/waste_viewset.py
@@ -65,7 +65,7 @@ class WasteViewSet(viewsets.ModelViewSet):
                     "Invalid date: date must be of format (YYYY-MM-DD)",
                     status=status.HTTP_400_BAD_REQUEST
                 )
-        
+
         # Start and End params
         try:
             # Adds date__gte field when start param is present and date__gte field when end param is present


### PR DESCRIPTION
Added parameter querying to `/waste` endpoint to improve performance.
`/waste?date=YYYY-MM-DD` get all waste for date
`/waste?start=YYYY-MM-DD` get all waste starting from date
`/waste?end=YYYY-MM-DD` get all waste until date
`/waste?start=YYYY-MM-DD&end=YYYY-MM-DD` get all waste between 2 dates