### PR TITLE
🐛 Only show active users in employees table + redirect edit to data add

### DIFF
--- a/frontend/src/components/table/SelectableTable.jsx
+++ b/frontend/src/components/table/SelectableTable.jsx
@@ -62,8 +62,8 @@ export default function SelectableTable({
           {columns.map((entry, index) => {
             return (
               <th
-                key={index}
-                className={"last:rounded-lg p-1 text-left bg-accent-1"}
+                key={index + 1}
+                className={"last:rounded-r-lg p-1 text-left bg-accent-1"}
               >
                 {entry.name}
               </th>

--- a/frontend/src/pages/beheer/personeel.jsx
+++ b/frontend/src/pages/beheer/personeel.jsx
@@ -22,6 +22,7 @@ import CustomButton from "@/components/button/Button";
 import SelectableTable from "@/components/table/SelectableTable";
 import Layout from "@/components/Layout";
 import { urlToPK } from "@/utils/urlToPK";
+import { useRouter } from "next/router";
 
 const initialContextMenu = {
   show: false,
@@ -39,10 +40,12 @@ export default function Employees() {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const searchRef = useRef(null);
+  const router = useRouter();
 
   useEffect(() => {
     const allUsers = async () => {
-      const response = await userService.get();
+      let response = await userService.get();
+      response = response.filter((user) => user.active && !user.removed);
       let user = [];
       for (let i in response) {
         let entry = response[i];
@@ -116,7 +119,9 @@ export default function Employees() {
   };
 
   const editUser = () => {
-    // To be implemented
+    const userIndex = selectedRows[0];
+    const userId = users[userIndex]["pk"];
+    router.push(`/beheer/data_toevoegen/personeel/${userId}`);
   };
 
   const deleteUsers = () => {
@@ -156,7 +161,6 @@ export default function Employees() {
   const multipleRowOptions = ["Verwijder", "Mail"];
 
   const changeSortSelected = (selected) => {
-    console.log(selected);
     setUsers(
       users.sort(function (a, b) {
         const field = stringToField[selected[0]];
@@ -254,11 +258,6 @@ export default function Employees() {
                 reference={searchRef}
                 callback={() => applySearch(filterSelected)}
               ></CustomInputField>
-            </div>
-            <div>
-              <PrimaryButton icon={faCirclePlus}>
-                <span className="mx-5-3">Nieuw</span>
-              </PrimaryButton>
             </div>
           </div>
         </PrimaryCard>

--- a/frontend/src/pages/beheer/syndici.jsx
+++ b/frontend/src/pages/beheer/syndici.jsx
@@ -22,6 +22,7 @@ import CustomModal from "@/components/Modals/CustomModal";
 import SelectableTable from "@/components/table/SelectableTable";
 import { urlToPK } from "@/utils/urlToPK";
 import Layout from "@/components/Layout";
+import { useRouter } from "next/router";
 
 const initialContextMenu = {
   show: false,
@@ -40,10 +41,12 @@ export default function Syndici() {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const searchRef = useRef(null);
+  const router = useRouter();
 
   useEffect(() => {
     const allUsers = async () => {
-      const response = await userService.get();
+      let response = await userService.get();
+      response = response.filter((user) => user.active && !user.removed);
       let user = [];
       for (let i in response) {
         let entry = response[i];
@@ -125,7 +128,9 @@ export default function Syndici() {
   };
 
   const editUser = () => {
-    // To be implemented
+    const userIndex = selectedRows[0];
+    const userId = users[userIndex]["pk"];
+    router.push(`/beheer/data_toevoegen/syndici/${userId}`);
   };
 
   const deleteUsers = () => {
@@ -263,11 +268,6 @@ export default function Syndici() {
                 reference={searchRef}
                 actionCallback={() => applySearch(filterSelected)}
               ></CustomInputField>
-            </div>
-            <div>
-              <PrimaryButton icon={faCirclePlus}>
-                <span className="mx-5-3">Nieuw</span>
-              </PrimaryButton>
             </div>
           </div>
         </PrimaryCard>


### PR DESCRIPTION
Closes #344 

Implemented here:

- Filter out non-active and deleted users in the employees en syndici tables
- Redirect the edit option to the correct page for a specific user