### PR TITLE
🐛/⚡️ Improve performance waste calls + fix waste error

### DIFF
--- a/frontend/src/components/forms/ScheduleForm.jsx
+++ b/frontend/src/components/forms/ScheduleForm.jsx
@@ -102,10 +102,9 @@ export default function ScheduleForm({ id }) {
 
   const fetchWaste = async (startDate, endDate, buildings) => {
     const wasteSchedule = {};
-    const wasteEntries = await WasteService.get({
-      startDate: startDate,
-      endDate: endDate,
-    });
+    const wasteEntries = await WasteService.getByDate(
+      dateFormat(startDate), dateFormat(endDate)
+    );
     buildings.map((building) => {
       const buildingUrl = building.building.url;
       wasteSchedule[building.building.url] = wasteEntries.filter(
@@ -124,6 +123,10 @@ export default function ScheduleForm({ id }) {
       setLoadSchedule(false);
     }
     setSelectedDate(newDate);
+  };
+
+  const dateFormat = (date) => {
+    return moment(date).add(1, "days").toDate().toISOString().substring(0, 10);
   };
 
   if (loading) {

--- a/frontend/src/components/forms/ScheduleForm.jsx
+++ b/frontend/src/components/forms/ScheduleForm.jsx
@@ -103,7 +103,8 @@ export default function ScheduleForm({ id }) {
   const fetchWaste = async (startDate, endDate, buildings) => {
     const wasteSchedule = {};
     const wasteEntries = await WasteService.getByDate(
-      dateFormat(startDate), dateFormat(endDate)
+      dateFormat(startDate),
+      dateFormat(endDate)
     );
     buildings.map((building) => {
       const buildingUrl = building.building.url;

--- a/frontend/src/components/forms/WasteForm.jsx
+++ b/frontend/src/components/forms/WasteForm.jsx
@@ -95,10 +95,10 @@ export default function WasteForm() {
         const sunday = moment(week[1])
           .add(weekCopy * i, "weeks")
           .toDate();
-        let wasteEntries = await wasteService.get({
-          startDate: monday,
-          endDate: sunday,
-        });
+        let wasteEntries = await wasteService.getByDate(
+          dateFormat(monday),
+          dateFormat(sunday)
+        );
         wasteEntries = wasteEntries.filter((w) =>
           buildingUrls.includes(w.building)
         );
@@ -147,15 +147,20 @@ export default function WasteForm() {
     setLoadSchedule(false);
   };
 
+  const dateFormat = (date) => {
+    return moment(date).add(1, "days").toDate().toISOString().substring(0, 10);
+  };
+
   useEffect(() => {
     // Fetch initial data
     async function fetchData() {
       setLoading(true);
       setAllTours(await TourService.get());
-      const wasteSchedule = await wasteService.get({
-        startDate: week[0],
-        endDate: week[1],
-      });
+      console.log("endate: " + week[1]);
+      const wasteSchedule = await wasteService.getByDate(
+        dateFormat(week[0]),
+        dateFormat(week[1])
+      );
       setWaste(wasteSchedule);
     }
 
@@ -178,10 +183,10 @@ export default function WasteForm() {
     setWeek([dateFrom, dateTo]);
     setLoadSchedule(true);
     // Fetch the waste schedule for the selected week
-    const wasteSchedule = await wasteService.get({
-      startDate: dateFrom,
-      endDate: dateTo,
-    });
+    const wasteSchedule = await wasteService.getByDate(
+      dateFormat(dateFrom),
+      dateFormat(dateTo)
+    );
     setWaste(wasteSchedule);
     if (Object.keys(tourBuildings).length !== 0) {
       setTourBuildings((prevTourBuildings) => {

--- a/frontend/src/services/waste.service.js
+++ b/frontend/src/services/waste.service.js
@@ -12,8 +12,21 @@ class WasteService {
    * @returns {Promise<*>} A list with waste entries.
    */
   async get(args = {}) {
-    let all = await HelperService.getAllPagination(`waste/`);
-    return this.#filterWaste(all, args);
+    let all = await HelperService.getResponseByUrl(`waste/`);
+    return this.#filterWaste(all.data, args);
+  }
+
+  /**
+   * Returns all waste entries that range from the startDate to the endDate
+   * @param startDate The startDate in "YYYY-MM-DD" format
+   * @param endDate The endDate in "YYYY-MM-DD" format
+   * @returns {Promise<*>} A list with waste entries.
+   */
+  async getByDate(startDate, endDate) {
+    let data = await HelperService.getResponseByUrl(
+      `waste?start=${startDate}&end=${endDate}`
+    );
+    return data.data;
   }
 
   /**


### PR DESCRIPTION
Closes #365 

- Fixed the waste error by replacing `getAllPagination` by `getResponseByUrl` because `/waste` no longer gives a paginated result.
- Made `getByDate` in `wasteService` that only returns wastes in the specific date via api endpoint.